### PR TITLE
React: Try only to listen for connections on localhost.

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+HOST=localhost


### PR DESCRIPTION
Allowing connections from non-localhost is a possible security issue, and should only be done when explicitly wanted:

    HOST=0.0.0.0 npm start

NOTE: I have no idea how the production server works, and am just crossing my fingers that this only affects dev.