### PR TITLE
Add transaction costs section to home

### DIFF
--- a/src/components/modules/donations/reports/TransactionCostsReport.tsx
+++ b/src/components/modules/donations/reports/TransactionCostsReport.tsx
@@ -1,0 +1,91 @@
+import { useAuth0 } from '@auth0/auth0-react';
+import React, { CSSProperties, useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { AppState } from '../../../../models/state';
+import { fetchTransactionCostsReportAction } from '../../../../store/donations/donation.actions';
+import { thousandize } from '../../../../util/formatting';
+import {
+  ReportContent,
+  ReportHeader,
+  ReportWrapper
+} from '../../shared/report/Report.style';
+
+const cellStyle: CSSProperties = { textAlign: 'right' };
+
+export const TransactionCostsReport = () => {
+  const report = useSelector(
+    (state: AppState) => state.donations?.transactionCostsReport
+  );
+  const dispatch = useDispatch();
+  const { getAccessTokenSilently } = useAuth0();
+
+  useEffect(() => {
+    getAccessTokenSilently().then((token) =>
+      dispatch(fetchTransactionCostsReportAction.started({ token }))
+    );
+  }, [dispatch, getAccessTokenSilently]);
+
+  const now = new Date();
+  const currentYear = now.getFullYear();
+
+  return (
+    <ReportWrapper>
+      <ReportHeader>Transaction Costs</ReportHeader>
+      <ReportContent>
+        <table width="100%">
+          <thead style={cellStyle}>
+            <tr>
+              <th></th>
+              <th>{currentYear - 1}</th>
+              <th>{currentYear}</th>
+              <th>Change</th>
+            </tr>
+          </thead>
+          <tbody>
+            <DataRow
+              label={`${getMonthName(now)} (to date)`}
+              currentVal={report?.costCurrentMonthToDate}
+              prevVal={report?.costCurrentMonthToDatePrevYear}
+            />
+            <DataRow
+              label={`${getMonthName(new Date(currentYear, now.getMonth() - 1))} (total)`}
+              currentVal={report?.costPrevMonth}
+              prevVal={report?.costPrevMonthPrevYear}
+            />
+            <DataRow
+              label={"Year to date"}
+              currentVal={report?.costYTD}
+              prevVal={report?.costYTDPrevYear}
+            />
+          </tbody>
+        </table>
+      </ReportContent>
+    </ReportWrapper>
+  );
+};
+
+const DataRow = ({ label, currentVal, prevVal }) => {
+  return <tr>
+    <td>{label}</td>
+    <td style={cellStyle}>{thousandize(prevVal)} kr</td>
+    <td style={cellStyle}>{thousandize(currentVal)} kr</td>
+    <td style={cellStyle}>{getPercentageChange(currentVal, prevVal)}</td>
+  </tr>
+}
+
+function getPercentageChange(newVal: string, oldVal: string): string {
+  const oldValParsed = parseFloat(oldVal);
+  const newValParsed = parseFloat(newVal);
+
+  if (isNaN(oldValParsed) || isNaN(newValParsed) || oldValParsed === 0) {
+    return "–";
+  }
+
+  const precentChange = Math.round(((newValParsed - oldValParsed) / oldValParsed) * 100);
+
+  return `${precentChange} %`;
+}
+
+function getMonthName(date: Date, lang = 'en') {
+  return date.toLocaleString(lang, { month: 'long' });
+}

--- a/src/components/pages/home/Home.tsx
+++ b/src/components/pages/home/Home.tsx
@@ -7,6 +7,7 @@ import { VippsReport } from '../../modules/vipps/report/VippsReport';
 import { LogsReport } from '../../modules/logs/report/LogsReport';
 import { MonthlyDonationsReport } from '../graphing/MonthlyDonationsReport';
 import { AvtaleGiroValidationTable } from '../../modules/avtalegiro/validationtable/AvtalegiroValidationTable';
+import { TransactionCostsReport } from '../../modules/donations/reports/TransactionCostsReport';
 
 export const HomeComponent: React.FunctionComponent = (props) => {
   return (
@@ -18,6 +19,7 @@ export const HomeComponent: React.FunctionComponent = (props) => {
         <VippsReport />
         <MonthlyDonationsReport />
         <LogsReport />
+        <TransactionCostsReport />
       </HomeGrid>
     </Page>
   );

--- a/src/models/state.ts
+++ b/src/models/state.ts
@@ -103,12 +103,22 @@ export interface CreateDonorState {}
 export interface DonationsState {
   currentDonation?: IDonation;
 
+  transactionCostsReport?: ITransactionCostsReport;
   histogram?: Array<IHistogramBucket>;
   pages: number;
   loading: boolean;
   pagination: IPagination;
   filter: IDonationFilter;
   donations: Array<IDonation>;
+}
+
+export interface ITransactionCostsReport {
+  costPrevMonth: string;
+  costPrevMonthPrevYear: string;
+  costCurrentMonthToDate: string;
+  costCurrentMonthToDatePrevYear: string;
+  costYTD: string;
+  costYTDPrevYear: string;
 }
 
 export interface TaxUnitsState {

--- a/src/root.saga.ts
+++ b/src/root.saga.ts
@@ -22,8 +22,8 @@ import {
   deleteDonationAction,
   fetchDonationsAction,
 } from './store/donations/donations-list.actions';
-import { fetchDonationAction, fetchHistogramAction } from './store/donations/donation.actions';
-import { fetchDonation, fetchHistogram } from './store/donations/donation.saga';
+import { fetchDonationAction, fetchHistogramAction, fetchTransactionCostsReportAction } from './store/donations/donation.actions';
+import { fetchDonation, fetchHistogram, fetchTransactionCostsReport } from './store/donations/donation.saga';
 import { fetchSumByMonth, fetchTotalByPeriod } from './store/graphing/graphing.saga';
 import { fetchSumByMonthAction, fetchTotalByPeriodAction } from './store/graphing/graphing.actions';
 import { fetchDistribution, fetchDistributions } from './store/distributions/distributions.saga';
@@ -151,6 +151,7 @@ function* watchAll() {
     takeLatest(fetchDonationsAction.started.type, fetchDonations),
     takeLatest(fetchDonationAction.started.type, fetchDonation),
     takeLatest(deleteDonationAction.started.type, deleteDonation),
+    takeLatest(fetchTransactionCostsReportAction.started.type, fetchTransactionCostsReport),
 
     takeLatest(fetchTotalByPeriodAction.started.type, fetchTotalByPeriod),
     takeLatest(fetchSumByMonthAction.started.type, fetchSumByMonth),

--- a/src/store/donations/donation.actions.ts
+++ b/src/store/donations/donation.actions.ts
@@ -1,4 +1,5 @@
 import actionCreatorFactory from 'typescript-fsa';
+import { ITransactionCostsReport } from '../../models/state';
 import { IDonation, IHistogramBucket } from '../../models/types';
 
 const actionCreator = actionCreatorFactory();
@@ -8,6 +9,10 @@ export interface IFetchDonationActionParams {
   token: string;
 }
 export interface IFetchDonationsHistogramActionParams {
+  token: string;
+}
+
+export interface IFetchTransactionCostsReportActionParams {
   token: string;
 }
 
@@ -24,3 +29,9 @@ export const fetchHistogramAction = actionCreator.async<
 
 export const CLEAR_CURRENT_DONATION = 'CLEAR_CURRENT_DONATION';
 export const clearCurrentDonation = () => ({ type: CLEAR_CURRENT_DONATION });
+
+export const fetchTransactionCostsReportAction = actionCreator.async<
+  IFetchTransactionCostsReportActionParams,
+  ITransactionCostsReport,
+  Error
+>('FETCH_TRANSACTION_COSTS_REPORT');

--- a/src/store/donations/donation.saga.ts
+++ b/src/store/donations/donation.saga.ts
@@ -4,6 +4,8 @@ import {
   IFetchDonationActionParams,
   fetchHistogramAction,
   IFetchDonationsHistogramActionParams,
+  IFetchTransactionCostsReportActionParams,
+  fetchTransactionCostsReportAction,
 } from './donation.actions';
 import { Action } from 'typescript-fsa';
 import * as API from '../../util/api';
@@ -33,5 +35,21 @@ export function* fetchHistogram(action: Action<IFetchDonationsHistogramActionPar
     yield put(fetchHistogramAction.done({ params: action.payload, result: result.content }));
   } catch (ex) {
     yield put(fetchHistogramAction.failed({ params: action.payload, error: (ex as Error) }));
+  }
+}
+
+export function* fetchTransactionCostsReport(action: Action<IFetchTransactionCostsReportActionParams>) {
+  try {
+    const result: API.Response = yield call(API.call, {
+      method: API.Method.GET,
+      endpoint: '/donations/transaction_costs_report',
+      token: action.payload.token,
+    });
+    if (result.status !== 200) throw new Error(result.content);
+    yield put(
+      fetchTransactionCostsReportAction.done({ params: action.payload, result: result.content })
+    );
+  } catch (ex) {
+    yield put(fetchTransactionCostsReportAction.failed({ params: action.payload, error: ex as Error }));
   }
 }

--- a/src/store/donations/donations.reducer.ts
+++ b/src/store/donations/donations.reducer.ts
@@ -5,6 +5,7 @@ import {
   fetchDonationAction,
   CLEAR_CURRENT_DONATION,
   fetchHistogramAction,
+  fetchTransactionCostsReportAction,
 } from './donation.actions';
 import { toastError } from '../../util/toasthelper';
 import Decimal from 'decimal.js';
@@ -20,6 +21,7 @@ import {
 
 const defaultState: DonationsState = {
   donations: [],
+  transactionCostsReport: undefined,
   loading: false,
   pages: 1,
   pagination: {
@@ -58,6 +60,15 @@ export const donationsReducer = (state = defaultState, action: any): DonationsSt
     return { ...state, loading: true };
   } else if (isType(action, fetchDonationsAction.failed)) {
     return { ...state, loading: false };
+  }
+
+  /**
+   * Transaction costs
+   */
+   if (isType(action, fetchTransactionCostsReportAction.done)) {
+    return { ...state, transactionCostsReport: action.payload.result };
+   } else if (isType(action, fetchTransactionCostsReportAction.failed)) {
+    toastError('Failed to fetch transaction costs report', action.payload.error.message);
   }
 
   /**

--- a/src/util/formatting.ts
+++ b/src/util/formatting.ts
@@ -8,4 +8,4 @@ export const longDateTime = (date: DateTime): string => {
   return date.toFormat('dd.MM.yyyy HH:mm');
 };
 
-export const thousandize = (number: number | null) => number !== null ? number.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ' ') : '-';
+export const thousandize = (number: number | null | undefined) => (number !== null && number !== undefined) ? number.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ' ') : '-';


### PR DESCRIPTION
Implements - https://github.com/stiftelsen-effekt/effekt-admin/issues/208
Note - Depends on backend changes - https://github.com/stiftelsen-effekt/effekt-backend/pull/474 to be merged

- Added component `TransactionCostsReport`
- Redux changes for getting transaction Costs Report data
- Added `undefined` handling to `thousandize` during intial data fetch

![image](https://user-images.githubusercontent.com/1507256/203962435-3f120b8a-0880-4f30-bf30-05bf4775dcbc.png)
