### PR TITLE
Time zone handling: Present in local time

### DIFF
--- a/src/components/modules/avtalegiro/agreementlist/AvtaleGiroList.tsx
+++ b/src/components/modules/avtalegiro/agreementlist/AvtaleGiroList.tsx
@@ -79,18 +79,12 @@ export const AvtaleGiroList: React.FunctionComponent<{
       Header: 'Draft date',
       id: 'created',
       accessor: (res: any) => shortDate(DateTime.fromISO(res.created, { setZone: true })),
-      sortMethod: (a: any, b: any) => {
-        return DateTime.fromFormat(a, 'dd.MM.yyyy') > DateTime.fromFormat(b, 'dd.MM.yyyy') ? -1 : 1;
-      },
       width: 110,
     },
     {
       Header: 'Last updated',
       id: 'lastUpdated',
-      accessor: (res: any) => longDateTime(DateTime.fromISO(res.last_updated, { setZone: true })),
-      sortMethod: (a: any, b: any) => {
-        return DateTime.fromFormat(a, 'dd.MM.yyyy') > DateTime.fromFormat(b, 'dd.MM.yyyy') ? -1 : 1;
-      },
+      accessor: (res: any) => longDateTime(DateTime.fromISO(res.last_updated)),
       width: 150,
     },
     {

--- a/src/components/modules/donations/list/DonationsList.tsx
+++ b/src/components/modules/donations/list/DonationsList.tsx
@@ -56,9 +56,6 @@ export const DonationsList: React.FunctionComponent<Props> = ({
       Header: 'Sum',
       id: 'sum',
       accessor: (res: any) => thousandize(res.sum) + ' kr',
-      sortMethod: (a: any, b: any) => {
-        return parseFloat(a.replace(' ', '')) > parseFloat(b.replace(' ', '')) ? -1 : 1;
-      },
       Cell: (row) => <span style={{ textAlign: 'right', width: '100%' }}>{row.value}</span>,
       width: 140,
     },
@@ -66,19 +63,13 @@ export const DonationsList: React.FunctionComponent<Props> = ({
       Header: 'Transaction cost',
       id: 'transactionCost',
       accessor: (res: any) => thousandize(res.transactionCost),
-      sortMethod: (a: any, b: any) => {
-        return parseFloat(a.replace(' ', '')) > parseFloat(b.replace(' ', '')) ? -1 : 1;
-      },
       Cell: (row) => <span style={{ textAlign: 'right', width: '100%' }}>{row.value}</span>,
       width: 115,
     },
     {
       Header: 'Timestamp',
       id: 'timestamp',
-      accessor: (res: any) => shortDate(DateTime.fromISO(res.timestamp, { setZone: true })),
-      sortMethod: (a: any, b: any) => {
-        return DateTime.fromFormat(a, 'dd.MM.yyyy') > DateTime.fromFormat(b, 'dd.MM.yyyy') ? -1 : 1;
-      },
+      accessor: (res: any) => shortDate(DateTime.fromISO(res.timestamp)),
       width: 100,
     },
   ];

--- a/src/components/modules/logs/list/LogsList.tsx
+++ b/src/components/modules/logs/list/LogsList.tsx
@@ -39,7 +39,7 @@ export const LogsList: React.FC<LogsListProps> = ({ showPagination = true, showM
     {
       Header: 'Timestamp',
       id: 'timestamp',
-      accessor: (res: any) => longDateTime(DateTime.fromISO(res.timestamp, { setZone: true })),
+      accessor: (res: any) => longDateTime(DateTime.fromISO(res.timestamp)),
       width: showMeta ? 150 : undefined,
     },
   ];

--- a/src/components/modules/taxunits/list/TaxUnitsList.tsx
+++ b/src/components/modules/taxunits/list/TaxUnitsList.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import ReactTable from 'react-table';
 import { useDispatch, useSelector } from 'react-redux';
 import { AppState } from '../../../../models/state';
-import { shortDate, thousandize } from '../../../../util/formatting';
+import { shortDate, thousandize, longDateTime } from '../../../../util/formatting';
 import { DateTime } from 'luxon';
 import { ITaxUnit } from '../../../../models/types';
 import { useAuth0 } from '@auth0/auth0-react';
@@ -70,11 +70,11 @@ export const TaxUnitList: React.FunctionComponent<Props> = ({
     {
       Header: 'Registered',
       id: 'registered',
-      accessor: (res: any) => shortDate(DateTime.fromISO(res.registered, { setZone: true })),
+      accessor: (res: any) => longDateTime(DateTime.fromISO(res.registered)),
       sortMethod: (a: any, b: any) => {
-        return DateTime.fromFormat(a, 'dd.MM.yyyy') > DateTime.fromFormat(b, 'dd.MM.yyyy') ? -1 : 1;
+        return DateTime.fromFormat(a, 'dd.MM.yyyy HH:mm') > DateTime.fromFormat(b, 'dd.MM.yyyy HH:mm') ? -1 : 1;
       },
-      width: 100,
+      width: 140,
     },
     {
       Header: 'Edit',

--- a/src/components/modules/vipps/agreementlist/VippsAgreementList.tsx
+++ b/src/components/modules/vipps/agreementlist/VippsAgreementList.tsx
@@ -52,9 +52,6 @@ export const VippsAgreementList: React.FunctionComponent<{
       id: 'amount',
       width: 110,
       accessor: (res: any) => thousandize(res.amount),
-      sortMethod: (a: any, b: any) => {
-        return parseFloat(a.replace(' ', '')) > parseFloat(b.replace(' ', '')) ? -1 : 1;
-      },
     },
     {
       Header: 'Charge day',
@@ -71,10 +68,7 @@ export const VippsAgreementList: React.FunctionComponent<{
     {
       Header: 'Draft date',
       id: 'created',
-      accessor: (res: any) => shortDate(DateTime.fromISO(res.timestamp_created, { setZone: true })),
-      sortMethod: (a: any, b: any) => {
-        return DateTime.fromFormat(a, 'dd.MM.yyyy') > DateTime.fromFormat(b, 'dd.MM.yyyy') ? -1 : 1;
-      },
+      accessor: (res: any) => shortDate(DateTime.fromISO(res.timestamp_created)),
       width: 120,
     },
   ];

--- a/src/components/modules/vipps/chargelist/VippsAgreementChargeList.tsx
+++ b/src/components/modules/vipps/chargelist/VippsAgreementChargeList.tsx
@@ -34,7 +34,7 @@ export const VippsAgreementChargeList: React.FunctionComponent = () => {
     {
       Header: 'Due date',
       id: 'dueDate',
-      accessor: (res: any) => shortDate(DateTime.fromISO(res.dueDate, { setZone: true })),
+      accessor: (res: any) => shortDate(DateTime.fromISO(res.dueDate)),
       width: 93,
     },
     {
@@ -70,7 +70,7 @@ export const VippsAgreementChargeList: React.FunctionComponent = () => {
     {
       Header: 'Created',
       id: 'created',
-      accessor: (res: any) => shortDate(DateTime.fromISO(res.timestamp_created, { setZone: true })),
+      accessor: (res: any) => shortDate(DateTime.fromISO(res.timestamp_created)),
       width: 98,
     },
     {

--- a/src/components/pages/logs/LogEntry.tsx
+++ b/src/components/pages/logs/LogEntry.tsx
@@ -57,7 +57,7 @@ export const LogEntryComponent: React.FunctionComponent<RouteComponentProps<IPar
           Log entry {entry.ID} | {entry.label}
         </ResourceHeader>
         <ResourceSubHeader>
-          {longDateTime(DateTime.fromISO(entry.timestamp, { setZone: true }))}
+          {longDateTime(DateTime.fromISO(entry.timestamp))}
         </ResourceSubHeader>
 
         <JSONView

--- a/src/store/donors/donor-page.reducer.ts
+++ b/src/store/donors/donor-page.reducer.ts
@@ -31,9 +31,7 @@ export const donorPageReducer = (
       ...state,
       donor: {
         ...action.payload.result,
-        registered: DateTime.fromISO(action.payload.result.registered.toString(), {
-          setZone: true,
-        }),
+        registered: DateTime.fromISO(action.payload.result.registered.toString()),
       },
     };
   } else if (isType(action, getDonorAction.started)) {

--- a/src/store/donors/donor-page.saga.ts
+++ b/src/store/donors/donor-page.saga.ts
@@ -149,7 +149,7 @@ export function* getDonorReferralAnswers(action: Action<IFetchDonorActionParams>
         getDonorReferralAnswersAction.done({
           params: action.payload,
           result: data.content.map((r) => {
-            r.timestamp = DateTime.fromISO(r.timestamp as any, { setZone: true });
+            r.timestamp = DateTime.fromISO(r.timestamp as any);
             return r;
           }),
         })
@@ -172,7 +172,7 @@ export function* getDonorTaxUnits(action: Action<IfetchDonorTaxUnitsParams>) {
         getDonorTaxUnitsAction.done({
           params: action.payload,
           result: data.content.map((r) => {
-            r.registered = DateTime.fromISO(r.registered as any, { setZone: true });
+            r.registered = DateTime.fromISO(r.registered as any);
             return r;
           }),
         })

--- a/src/store/donors/donor-selection.reducer.ts
+++ b/src/store/donors/donor-selection.reducer.ts
@@ -26,7 +26,7 @@ export const donorSelectorReducer = (
       searchResult: action.payload.result.map((donor: IDonor) => {
         return {
           ...donor,
-          registered: DateTime.fromISO(donor.registered.toString(), { setZone: true }),
+          registered: DateTime.fromISO(donor.registered.toString()),
         };
       }),
     };

--- a/src/store/single-donation/single-donation.reducer.ts
+++ b/src/store/single-donation/single-donation.reducer.ts
@@ -31,7 +31,7 @@ export const singleDonationReducer = (
       paymentMethods: action.payload.result.map((method: IPaymentMethod) => {
         return {
           ...method,
-          lastUpdated: DateTime.fromISO(method.lastUpdated.toString(), { setZone: true }),
+          lastUpdated: DateTime.fromISO(method.lastUpdated.toString()),
         };
       }),
     };


### PR DESCRIPTION
Prevent printing UTC timestamps as UTC timestamps except for dates.

This standardizes on everything being handled in local timezone. So given this scenario:

1. You have a computer in Japan, running Japanese time, UTC+9
2. You want to search for donors registered on 2022-01-01
3. Your browser uses your local UTC+9 time in the search, and finds a donor that registered at 2021-12-31 22:00 CET
4. The result is sent back as 2021-12-31 21:00 UTC
5. Your computer interprets the registration time as 2022-01-01 06:00 because of the time difference, so it apparently matches your search.

This might or might not be what we actually want. Three options that each have their merit:

1. Go all-in on local timezone on frontend, UTC backend (we are pretty much there now)
2. Go all-in on reinterpreting and presenting as 'Europe/Oslo' on the frontend, regardless of local time.
3. Go all-UTC, everywhere.